### PR TITLE
Configure memory limit on ElasticSearch container in development

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -119,6 +119,10 @@ services:
 
   # ELasticsearch
   elasticsearch:
+    deploy:
+      resources:
+        limits:
+          memory: 2G
 #    platform: amd64
     image: docker.elastic.co/elasticsearch/elasticsearch:8.3.3
     ports:

--- a/docker-dev.sh
+++ b/docker-dev.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 if [ $1 == "up" ]
 then
-  docker-compose -f docker-compose.dev.yml -p clowder2-dev up -d
+  docker-compose --compatibility -f docker-compose.dev.yml -p clowder2-dev up -d
 fi
 if [ $1 == "down" ]
 then


### PR DESCRIPTION
Adds a small stanza to `docker-compose.dev.yml` to limit ElasticSearch container to 2 GB of memory.
Add `--compatibility` flag to `docker-dev.sh` to allow Docker Compose to make use of the configured limit.

Reference: https://stackoverflow.com/a/57135933
